### PR TITLE
Saving full .parquet file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ extractor/vendor
 #*
 .DS_Store
 *.iml
+*~

--- a/extractor/cli/main.go
+++ b/extractor/cli/main.go
@@ -12,7 +12,7 @@ import (
 
 var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
 var memprofile = flag.String("memprofile", "", "write memory profile to this file")
-var n = flag.Uint64("n", 0, "number of repositories, 0 = All from DB")
+var limit = flag.Uint64("limit", 0, "number of repositories, 0 = All from DB")
 
 func main() {
 	flag.Parse()
@@ -25,8 +25,8 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	extractorService := extractor.NewService()
-	repos, err := extractorService.GetRerpoData(*n)
+	extractorService := extractor.NewService(*limit)
+	repos, err := extractorService.GetRepositoriesData()
 	checkIfError(err)
 	fmt.Printf("Repos returned: %d\n", len(repos))
 

--- a/extractor/cli/main.go
+++ b/extractor/cli/main.go
@@ -12,6 +12,7 @@ import (
 
 var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
 var memprofile = flag.String("memprofile", "", "write memory profile to this file")
+var n = flag.Uint64("n", 0, "number of repositories, 0 = All from DB")
 
 func main() {
 	flag.Parse()
@@ -25,7 +26,7 @@ func main() {
 	}
 
 	extractorService := extractor.NewService()
-	repos, err := extractorService.GetRepositoriesData()
+	repos, err := extractorService.GetRerpoData(*n)
 	checkIfError(err)
 	fmt.Printf("Repos returned: %d\n", len(repos))
 

--- a/extractor/glide.lock
+++ b/extractor/glide.lock
@@ -1,19 +1,28 @@
-hash: 9102d7bfae648f8494798a476d3853bc6e6cdbc4476bb41462a23ddb85f84d5a
-updated: 2017-07-12T09:30:04.99725705+02:00
+hash: 28df3ad771be2c058e02744a2bfdd93614f928b50a43e2f430590f417b5d111b
+updated: 2017-07-17T10:29:44.265205115+02:00
 imports:
 - name: github.com/bblfsh/sdk
-  version: 67d54901d8ea4929ec5ff4a812825fd6ca6303b0
+  version: c829390f1f87d418285ebacb63bb0b201c6ea903
   subpackages:
   - protocol
   - uast
+- name: github.com/coreos/etcd
+  version: 9ce7bb6a1c15bcffdd011a571dc686e71aabc314
+  subpackages:
+  - auth/authpb
+  - clientv3
+  - clientv3/concurrency
+  - etcdserver/api/v3rpc/rpctypes
+  - etcdserver/etcdserverpb
+  - mvcc/mvccpb
 - name: github.com/gogo/protobuf
-  version: 9df9efe4c742f1a2bfdedf1c3b6902fc6e814c6b
+  version: 100ba4e885062801d56799d78530b73b178a78f3
   subpackages:
   - gogoproto
   - proto
   - protoc-gen-gogo/descriptor
 - name: github.com/golang/protobuf
-  version: 6e4cc92cc905d5f4a73041c1b8228ea08f4c6147
+  version: 0a4f71a498b7c4812f64969510bcb4eca251e33a
   subpackages:
   - proto
   - ptypes/any
@@ -32,13 +41,15 @@ imports:
 - name: github.com/mattn/go-colorable
   version: 3fa8c76f9daed4067e4a806fb7e4dc86455c6d6a
 - name: github.com/mattn/go-isatty
-  version: 57fdcb988a5c543893cc61bce354a6e24ab70022
+  version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
 - name: github.com/mcuadros/go-defaults
   version: e1c978be3307be96ef03a0bd25d719ab50d277e4
 - name: github.com/oklog/ulid
   version: 66bb6560562feca7045b23db1ae85b01260f87c5
+- name: github.com/pkg/errors
+  version: c605e284fe17294bda444b34710735b29d1a9d90
 - name: github.com/satori/go.uuid
-  version: 879c5887cd475cd7864858769793b2ceb0d44feb
+  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: github.com/serenize/snaker
   version: 1c7f65329f6524115af8ca01ab604c00cddf5558
 - name: github.com/sergi/go-diff
@@ -60,7 +71,7 @@ imports:
 - name: github.com/xanzy/ssh-agent
   version: ba9c9e33906f58169366275e3450db66139a31a9
 - name: golang.org/x/crypto
-  version: 3627ff35f31987174dbee61d9d1dcc1c643e7174
+  version: 7f7c0c2d75ebb4e32a21396ce36e87b6dadc91c9
   subpackages:
   - curve25519
   - ed25519
@@ -69,7 +80,7 @@ imports:
   - ssh/agent
   - ssh/knownhosts
 - name: golang.org/x/net
-  version: 3da985ce5951d99de868be4385f21ea6c2b22f24
+  version: b3756b4b77d7b13260a0a2ec658753cf48922eac
   subpackages:
   - context
   - http2
@@ -79,11 +90,11 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: 4cd6d1a821c7175768725b55ca82f14683a29ea4
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 4ee4af566555f5fbe026368b75596286a312663a
+  version: 836efe42bb4aa16aaa17b9c155d8813d336ed720
   subpackages:
   - secure/bidirule
   - transform
@@ -101,11 +112,11 @@ imports:
   - internal/modules
   - internal/remote_api
 - name: google.golang.org/genproto
-  version: d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
+  version: b0a3dcfcd1a9bd48e63634bd8802960804cf8315
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 79f73d62e5082ee8d6b86a2487fd6267c1495fcd
+  version: b15215fb911b24a5d61d57feec4233d610530464
   subpackages:
   - codes
   - credentials
@@ -125,13 +136,8 @@ imports:
   subpackages:
   - stack
   - term
-- name: gopkg.in/mgo.v2
-  version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
-  subpackages:
-  - bson
-  - internal/json
 - name: gopkg.in/src-d/core-retrieval.v0
-  version: bf9b3d791c9df25da40efe0950c647713cc13f50
+  version: 83bf9ada96f00497f460c36879d53c980f060e18
   subpackages:
   - model
   - repository
@@ -140,14 +146,16 @@ imports:
   subpackages:
   - model
 - name: gopkg.in/src-d/enry.v1
-  version: ad46ae50f84afb299328225ecd82c9d3f6acb9e8
+  version: b2b40bbfc59fa9ab248d8662edca78839195a7a6
   subpackages:
+  - data
   - internal/tokenizer
 - name: gopkg.in/src-d/framework.v0
-  version: 06c61f8f6a8913f3d4d465bab758ff06c0b3d920
+  version: b7e5e412473a20a56c0543f898624f024b164087
   subpackages:
   - configurable
   - database
+  - lock
   - queue
 - name: gopkg.in/src-d/go-billy-siva.v3
   version: b15b35bba22ab049715a74125fb100faee83cd00
@@ -159,9 +167,10 @@ imports:
   - helper/polyfill
   - osfs
   - util
+- name: gopkg.in/src-d/go-errors.v0
+  version: 6f07baca276330431b44ece8ee84ac98167bc4ea
 - name: gopkg.in/src-d/go-git.v4
-  version: ce6f5b7c82fc6c2c4d41880ed6b26f921dd9c1c3
-  repo: https://github.com/src-d/go-git.git
+  version: d3c7400c39f86a4c59340c7a9cda8497186e00fc
   subpackages:
   - config
   - internal/revision
@@ -203,7 +212,7 @@ imports:
   - utils/merkletrie/internal/frame
   - utils/merkletrie/noder
 - name: gopkg.in/src-d/go-kallax.v1
-  version: 2cc6c43422cceee02f3b75a702973fe3834f831f
+  version: 2acd313ffa7ae1f67edec6556600ce2358be3c79
   subpackages:
   - types
 - name: gopkg.in/src-d/go-siva.v1

--- a/extractor/glide.yaml
+++ b/extractor/glide.yaml
@@ -1,30 +1,34 @@
 package: github.com/src-d/berserker/extractor
 import:
+- package: github.com/bblfsh/sdk
+  version: c829390f1f87d418285ebacb63bb0b201c6ea903
+  subpackages:
+  - protocol
 - package: github.com/gogo/protobuf
+  version: ^0.4.0
   subpackages:
   - gogoproto
 - package: github.com/golang/protobuf
   subpackages:
   - proto
-- package: google.golang.org/grpc
-- package: gopkg.in/src-d/enry.v1
-- package: gopkg.in/src-d/go-git.v4
-  repo: https://github.com/src-d/go-git.git
-  version: ce6f5b7c82fc6c2c4d41880ed6b26f921dd9c1c3
+- package: github.com/inconshreveable/log15
+  version: ^2.11.0
+- package: golang.org/x/net
   subpackages:
-  - config
-  - plumbing
-  - plumbing/object
-  - plumbing/storer
-  - plumbing/transport
-  - plumbing/transport/client
-  - plumbing/transport/server
-  - storage/filesystem
-  - utils/ioutil
+  - context
+- package: google.golang.org/grpc
+  version: ^1.4.2
 - package: gopkg.in/src-d/core-retrieval.v0
-  version: bf9b3d791c9df25da40efe0950c647713cc13f50
+- package: gopkg.in/src-d/core.v0
   subpackages:
   - model
-  - repository
-- package: github.com/bblfsh/sdk
-  version: 67d54901d8ea4929ec5ff4a812825fd6ca6303b0
+- package: gopkg.in/src-d/enry.v1
+  version: ^1.3.0
+- package: gopkg.in/src-d/go-git.v4
+  version: ^4.0.0-rc12
+  subpackages:
+  - plumbing
+  - plumbing/object
+  - storage
+- package: golang.org/x/crypto
+  version: 7f7c0c2d75ebb4e32a21396ce36e87b6dadc91c9

--- a/extractor/server.proteus.go
+++ b/extractor/server.proteus.go
@@ -8,8 +8,8 @@ type extractorServiceServer struct {
 	Service *Service
 }
 
-func NewExtractorServiceServer() *extractorServiceServer {
-	return &extractorServiceServer{NewService()}
+func NewExtractorServiceServer(limit uint64) *extractorServiceServer {
+	return &extractorServiceServer{NewService(limit)}
 }
 func (s *extractorServiceServer) Service_GetRepositoriesData(ctx context.Context, in *Service_GetRepositoriesDataRequest) (result *Service_GetRepositoriesDataResponse, err error) {
 	result = new(Service_GetRepositoriesDataResponse)

--- a/extractor/server/server.go
+++ b/extractor/server/server.go
@@ -28,7 +28,7 @@ func main() {
 		panic(err)
 	}
 
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(grpc.MaxSendMsgSize(extractor.GrpcMaxMsgSize))
 
 	extractor.RegisterExtractorServiceServer(grpcServer, extractor.NewExtractorServiceServer(*limit))
 	log.Info("server started", "address", grpcAddr)

--- a/extractor/server/server.go
+++ b/extractor/server/server.go
@@ -13,11 +13,12 @@ import (
 )
 
 var profiler = flag.Bool("profiler", false, "start CPU & memeory profiler")
+var limit = flag.Uint64("limit", 0, "number of repositories, 0 = All from DB")
 
 func main() {
 	flag.Parse()
 	// TODO parametrize
-	profilerAddr := "localhost:6062"
+	profilerAddr := "localhost:6063"
 	grpcAddr := "localhost:8888"
 
 	startHTTPProfilingMaybe(profilerAddr)
@@ -29,7 +30,7 @@ func main() {
 
 	grpcServer := grpc.NewServer()
 
-	extractor.RegisterExtractorServiceServer(grpcServer, extractor.NewExtractorServiceServer())
+	extractor.RegisterExtractorServiceServer(grpcServer, extractor.NewExtractorServiceServer(*limit))
 	log.Info("server started", "address", grpcAddr)
 
 	err = grpcServer.Serve(lis)

--- a/extractor/service.go
+++ b/extractor/service.go
@@ -63,7 +63,7 @@ func (s *Service) getRerposData(n uint64) ([]*RepositoryData, error) {
 	log.Info("Iterating over N repositories in DB", "N", n)
 
 	const master = "refs/heads/master"
-	result := make([]*RepositoryData, n)
+	var result []*RepositoryData
 
 	reposNum := 0
 	totalFiles := 0

--- a/extractor/service.go
+++ b/extractor/service.go
@@ -69,7 +69,7 @@ func (s *Service) getRerposData(n uint64) ([]*RepositoryData, error) {
 	totalFiles := 0
 	for masterRefInit, repoMetadata := range findAllFetchedReposWithRef(master, n) {
 		repo, processedFiles, err := s.processRepository(repoMetadata, master, masterRefInit)
-		if err != nil && repo == nil { //partially processed repos are OK
+		if err != nil && repo == nil { // partially processed repos are OK
 			//TODO(bzz): move loggin/error handing here instead of s.processRepository()
 			continue
 		}
@@ -80,6 +80,12 @@ func (s *Service) getRerposData(n uint64) ([]*RepositoryData, error) {
 	}
 
 	log.Info("Done. All files in all repositories parsed", "repositories", reposNum, "files", totalFiles)
+
+	log.Debug("Serializing files in", "repositories", len(result))
+	for _, r := range result {
+		log.Debug("Repository", "ID", r.RepositoryID, "URL", r.URL, "number of files", len(r.Files))
+	}
+
 	return result, nil
 }
 

--- a/extractor/service.go
+++ b/extractor/service.go
@@ -210,10 +210,10 @@ func parseToUast(client protocol.ProtocolServiceClient, fName string, fLang stri
 	//TODO(bzz): take care of non-UTF8 things, before sending them
 	//  - either encode in utf8
 	//  - or convert to base64() and set encoding param
-	req := &protocol.ParseUASTRequest{
+	req := &protocol.ParseRequest{
 		Content:  fContent,
 		Language: fLang}
-	resp, err := client.ParseUAST(context.TODO(), req)
+	resp, err := client.Parse(context.TODO(), req)
 	if err != nil {
 		log.Error("ParseUAST failed on gRPC level", "file", fName, "err", err)
 		return nil, err

--- a/extractor/service.go
+++ b/extractor/service.go
@@ -30,8 +30,14 @@ type Service struct {
 func NewService(n uint64) *Service {
 	//TODO(bzz): parametrize
 	bblfshAddr := "0.0.0.0:9432"
+	grpcMaxMsgSize := 100 * 1024 * 1024
 	log.Info("Connecting to Bblfsh server", "address", bblfshAddr)
-	bblfshConn, err := grpc.Dial(bblfshAddr, grpc.WithTimeout(time.Second*2), grpc.WithInsecure())
+	bblfshConn, err := grpc.Dial(bblfshAddr,
+		grpc.WithTimeout(time.Second*2),
+		grpc.WithInsecure(),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(grpcMaxMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(grpcMaxMsgSize)),
+	)
 	client := protocol.NewProtocolServiceClient(bblfshConn)
 	checkIfError(err)
 

--- a/extractor/service.go
+++ b/extractor/service.go
@@ -23,6 +23,7 @@ import (
 )
 
 const maxNumOfThousendsOfFilesToProcsee = 10
+const	GrpcMaxMsgSize = 100 * 1024 * 1024
 
 type Service struct {
 	bblfshClient protocol.ProtocolServiceClient
@@ -32,13 +33,12 @@ type Service struct {
 func NewService(n uint64) *Service {
 	//TODO(bzz): parametrize
 	bblfshAddr := "0.0.0.0:9432"
-	grpcMaxMsgSize := 100 * 1024 * 1024
 	log.Info("Connecting to Bblfsh server", "address", bblfshAddr)
 	bblfshConn, err := grpc.Dial(bblfshAddr,
 		grpc.WithTimeout(time.Second*2),
 		grpc.WithInsecure(),
-		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(grpcMaxMsgSize)),
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(grpcMaxMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(GrpcMaxMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(GrpcMaxMsgSize)),
 	)
 	client := protocol.NewProtocolServiceClient(bblfshConn)
 	checkIfError(err)

--- a/extractor/service.go
+++ b/extractor/service.go
@@ -23,7 +23,7 @@ import (
 )
 
 const maxNumOfThousendsOfFilesToProcsee = 10
-const	GrpcMaxMsgSize = 100 * 1024 * 1024
+const GrpcMaxMsgSize = 100 * 1024 * 1024
 
 type Service struct {
 	bblfshClient protocol.ProtocolServiceClient
@@ -145,7 +145,6 @@ func (s *Service) processRepository(repoMetadata *model.Repository, master strin
 			errFiles++
 			return nil
 		}
-		//log.Debug(fmt.Sprintf("\t%-9s blob %s    %s", fLang, f.Hash, f.Name))
 
 		// Babelfish -> UAST (Python, Java)
 		if strings.EqualFold(fLang, "java") || strings.EqualFold(fLang, "python") {

--- a/normalizer/src/main/scala/tech/sourced/berserker/normalizer/service/ExtractorService.scala
+++ b/normalizer/src/main/scala/tech/sourced/berserker/normalizer/service/ExtractorService.scala
@@ -5,9 +5,13 @@ import io.grpc.ManagedChannelBuilder
 import org.apache.spark.sql.Row
 
 class ExtractorService(host: String, port: Int, isPlainText: Boolean = true) {
+
+  private val maxGrpcMsgSize = 100 * 1042 * 1042
   private val channel = ManagedChannelBuilder
     .forAddress(host, port)
-    .usePlaintext(isPlainText).build()
+    .usePlaintext(isPlainText)
+    .maxInboundMessageSize(maxGrpcMsgSize)
+    .build()
 
   private val stub = ExtractorServiceGrpc.blockingStub(channel)
 


### PR DESCRIPTION
  - [x] pass CLI arg `--limit=N`to limit number of processed repos to aid debugging
  - [x] increase Berserker internal gRPC max msg size limit to 100mb
  - [x] increase Berserker -> Bblfsh server gRPC max msg size limit to 100mb
  - [x] add repoURL to .parquet file
  - [x] fixes #14 

Set of .parquet files was produced, using these changes.

## Test Plan

```
#with latest local build of bblfsh-server
docker run -e 'BBLFSH_DRIVER_IMAGES="python=docker-daemon:bblfsh/python-driver:dev-4dd607b;java=docker-daemon:bblfsh/java-driver:dev-45a5e8f"' --privileged -p 9432:9432 --name bblfsh bblfsh/server:dev-6bc7fd7 --max-message-size 100

cd extractor
go build -o extractor-server  ./server/*.go
./extractor-server -profiler -limit 10

cd normalizer
./sbt run
```

Instructions in #16 could be used to verify resulting format: UAST pb format